### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol server for interacting with Strapi CMS. This server enables AI assistants to interact with your Strapi instance through a standardized interface, supporting content types and REST API operations.
 
+<a href="https://glama.ai/mcp/servers/qfdkybxvkp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/qfdkybxvkp/badge" alt="Strapi Server MCP server" />
+</a>
+
 ## Changelog
 
 ### Version 2.3.0 - Documentation & Configuration Enhancement
@@ -17,7 +21,7 @@ A Model Context Protocol server for interacting with Strapi CMS. This server ena
 ### Version 2.2.0 - Security & Version Handling Update
 
 - 🔒 Added strict write protection policy
-- 🔄 Enhanced version format support (5.\*, 4.1.5, v4, etc.)
+- 🔄 Enhanced version format support (5.* , 4.1.5, v4, etc.)
 - 📚 Integrated documentation into server capabilities
 - 🚫 Removed connect prompt (now in capabilities)
 - ⚡ Improved error handling and validation


### PR DESCRIPTION
This PR adds a badge for the [Strapi MCP Server](https://glama.ai/mcp/servers/qfdkybxvkp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/qfdkybxvkp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/qfdkybxvkp/badge" alt="Strapi Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.